### PR TITLE
Explicitly grant required permissions to workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,9 @@
 name: Docs
 
+permissions:
+  pages: write
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
GitHub [has recently changed](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/) the default permissions of workflows to be read-only for security reasons.

This causes the action to fail on repositories that don't explicitly grant all possible permissions to the workflows, meaning every repository created after the 2nd of February 2023 doesn't work per default.

To fix this in a secure manner, I manually specified the required `permissions` in the workflow file.
Tested on both a dummy repository and a production one.