### PR TITLE
Bump `checkout` version from v2 -> v3

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
       SLIDES: true
       BRANCH: gh-pages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: quirinecker/asciidoctor-convert-action@main
         with:


### PR DESCRIPTION
This PR bumps the version of the `actions/checkout` workflow from `v2` to `v3`.

The old one is deprecated and uses node 12.